### PR TITLE
Remove April Fools function

### DIFF
--- a/ClassicCastbars/core/PoolManager.lua
+++ b/ClassicCastbars/core/PoolManager.lua
@@ -68,11 +68,3 @@ end
     print(format("Created %d frames in total.", framesCreated))
     print(format("Currently active frames: %d.", framesActive))
 end]]
-
-if date("%d.%m") == "01.04" then -- April Fools :)
-    C_Timer.After(1800, function()
-        if not UnitIsDeadOrGhost("player") then
-            DoEmote(math.random(0, 1) == 1 and "fart" or "nosepick")
-        end
-    end)
-end


### PR DESCRIPTION
This is extremely annoying if you're in a large group where it feels like it goes off constantly and spams the chat.